### PR TITLE
Fix: Rename aux link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ You are expected to be familiar with the operations of `docker` and `docker-comp
 
 ## How to use this project?
 
-Please refer to scripts found in [./deployments](../deployments) to get information learn about orchestration and operations of [Fabric CA][1].
+Please refer to scripts found in [./deployments](../deployments) to get information learn about orchestration and operations of [Fabric CA][1]. Use this demonstrator together with the [official operational guide](https://hyperledger-fabric-ca.readthedocs.io/en/release-1.4/operations_guide.html) to help you learn about the technology.
  
 Use this project to perform these operations:
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,5 +4,5 @@ color_scheme: "light"
 search_enabled: true
 
 aux_links:
-    "Fabric CA analysis on GitHub":
+    "Click here to see the codes in GitHub":
       - "//github.com/openconsentia/fabric-ca-analysis"


### PR DESCRIPTION
This is to make it clear what the link is for.